### PR TITLE
Update Menu Items and References to GRIG STU3

### DIFF
--- a/input/pagecontent/StructureDefinition-GdxVariant-intro.md
+++ b/input/pagecontent/StructureDefinition-GdxVariant-intro.md
@@ -1,2 +1,2 @@
 
-For additional details on how to use this profile, please review the [Variant Reporting](https://hl7.org/fhir/uv/genomics-reporting/STU2/sequencing.html) page in the Genomics Reporting Implemention Guide.
+For additional details on how to use this profile, please review the [Variant Reporting](https://build.fhir.org/ig/HL7/genomics-reporting/sequencing.html) page in the Genomics Reporting Implemention Guide.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -68,4 +68,4 @@ Details for Transport are described in [Transport Messaging](transport.html)
 
 ### Credits
 
-Our thanks to the contributors to the CodeX/GenomeX data exchange work stream which drive the guidance in this IG.
+Our thanks to the contributors to the CodeX/GenomeX data exchange work stream which drives the guidance in this IG.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,6 +1,6 @@
 
 ### Background
-There is an ongoing need to expand and standardize genomic test results that are exchanged between laboratories, EHR vendors and other interested stakeholders.  The work of the [HL7 Clinical Genomics Working Group (CGWG)](https://confluence.hl7.org/display/CGW) and their [HL7 Genomics Reporting FHIR Implementation Guide (GRIG)](http://hl7.org/fhir/uv/genomics-reporting/STU2/), to design and build, scalable FHIR genomics interfaces, is enabling the appropriate data to be sent to EHRs and genomics repositories.
+There is an ongoing need to expand and standardize genomic test results that are exchanged between laboratories, EHR vendors and other interested stakeholders.  The work of the [HL7 Clinical Genomics Working Group (CGWG)](https://confluence.hl7.org/display/CGW) and their [HL7 Genomics Reporting FHIR Implementation Guide (GRIG)](https://build.fhir.org/ig/HL7/genomics-reporting/), to design and build, scalable FHIR genomics interfaces, is enabling the appropriate data to be sent to EHRs and genomics repositories.
 
 The Genomics Reporting IG is a comprehensive guide, but is too broad for the specific needs of the GenomeX Data Exchange community. More specific guidance is needed to constrain the GRIG to meet the scope of the Data Exchange use case.
 
@@ -11,7 +11,7 @@ This FHIR implementation guide (IG) is intended to organize modeling guidance fo
 ### Scope
 
 This first draft will focus on the following:
-* Genomics Reporting FHIR IG 2.0.0
+* Genomics Reporting FHIR IG 3.0.1
 * mCODE STU 3.0.0
 * FHIR R4
 * a basic set of data elements usable by providers for diagnosis, treatment, and monitoring

--- a/input/pagecontent/payload.md
+++ b/input/pagecontent/payload.md
@@ -13,11 +13,11 @@ As shown in Figure 1 below, the Genomic payload has multiple resources, the prin
 ### Payload Development Process
 The Data Exchange use case worked across the data creating member to develop the initial consensus for genomic report information that would be included in Phase 0, the initial implementation of the GRIG. To understand what data required FHIR representation, the members provided the basic data elements  that needed to be delivered as part of their existing genomic test results. Along with the data elements, metadata about each element were also captured, including any required elements, data element code system(s), and code systems that can be implemented now or in the future. 
 
-Once the data elements were catalogued, the members mapped them to an appropriate set of FHIR resources based on FHIR R4, the GRIG STU2, and mCODE STU3. The results were compared across the report producers to determine the overlapping set of FHIR resources. Those that were common or closely aligned between the report producers were agreed upon as the initial set for this IG.
+Once the data elements were catalogued, the members mapped them to an appropriate set of FHIR resources based on FHIR R4, the GRIG STU3, and mCODE STU3. The results were compared across the report producers to determine the overlapping set of FHIR resources. Those that were common or closely aligned between the report producers were agreed upon as the initial set for this IG.
 
 These data elements were the focus of Phase 0 and will represent a starting point for this IG. 
 
-For additional context, samples for a variety of report types, such as general genomic reporting, somatic reporting, variant reporting, and PGx reporting are available under the [How to Use This Guide](http://hl7.org/fhir/uv/genomics-reporting/STU2/index.html#how-to-use-this-guide) section of the [Genomics Reporting IG (STU2)](http://hl7.org/fhir/uv/genomics-reporting/STU2).
+For additional context, samples for a variety of report types, such as general genomic reporting, somatic reporting, variant reporting, and PGx reporting are available under the [How to Use This Guide](https://build.fhir.org/ig/HL7/genomics-reporting/#how-to-use-this-guide) section of the [Genomics Reporting IG (STU3)](https://build.fhir.org/ig/HL7/genomics-reporting/).
 
 ### Outcomes 
 The major outcomes of the payload development process are represented by the constraints on the FHIR resources in this IG and shown in the profiles. In addition, there are other design decisions that are shown below to help guide the Data Exchange community through early implementation of FHIR in their workflows. 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -85,6 +85,11 @@ menu:
     Report Overview: overview.html
     Transport: transport.html
     Content (Payload): payload.html
+  Reporting:
+    Somatic Testing: somatic_reporting.html
+    Germline Oncology Testing: germline_oncology_reporting.html
+    Germline Prenatal Testing: germline_prenatal_reporting.html
+    Biomarker Testing: biomarker_reporting.html
   Examples:
     Extended Example: example_extended.html
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -82,8 +82,9 @@ menu:
   Home: index.html
   Artifacts: artifacts.html
   Guidance:
+    Report Overview: overview.html
     Transport: transport.html
-    Payload: payload.html
+    Content (Payload): payload.html
   Examples:
     Extended Example: example_extended.html
 


### PR DESCRIPTION
URL to use for GRIG STU3: https://build.fhir.org/ig/HL7/genomics-reporting/

- [x] Added ‘Report Overview’ to ‘Guidance’ menu (Guidance > Report Overview)
- [x] Report Transport: Double checked info, links and references to STU2 as mentioned above; no changes made
- [x] Report Content (Payload): updated all references of GRIG STU2 to GRIG STU3, including URLs and text
- [x] Changed the 'Payload' menu item to 'Content (Payload)'
- [x] Updated index.md with version bump from 2.0.0 to 3.0.1
- [x] Updated StructureDefinition-GdxVariant-intro.md URL to point to GRIG STU3 Variant Reporting Page (https://build.fhir.org/ig/HL7/genomics-reporting/sequencing.html)